### PR TITLE
Add note on unauthenticatedReport error requiring new PrepareError variant

### DIFF
--- a/draft-priebe-ppm-dap-reportauth.md
+++ b/draft-priebe-ppm-dap-reportauth.md
@@ -147,6 +147,10 @@ following error type:
 |                       | input share token or no token was         |
 |                       | provided                                  |
 
+> TODO: This should be a new PrepareError variant, rather than a new
+> error type URI, see
+> https://github.com/cpriebe/draft-priebe-ppm-dap-reportauth/issues/8
+
 The terms used follow the definitions in {{!DAP}} and {{!PPARCH}}. In
 addition, the following terms are used throughout this document:
 


### PR DESCRIPTION
Related: https://github.com/cpriebe/draft-priebe-ppm-dap-reportauth/issues/8